### PR TITLE
Rétablir « Rubrique Saisonnière » dans le menu

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -55,6 +55,9 @@ class Layout extends React.Component {
                 <Link to="/vallee">Vallée de Sye et Gervanne</Link>
               </li>
               <li>
+                <Link to="/rubrique">Rubrique Saisonnière</Link>
+              </li>
+              <li>
                 <Link to="/plan">Plan d'accès</Link>
               </li>
               <li>


### PR DESCRIPTION
## Résumé

- rétablit l’entrée « Rubrique Saisonnière » dans le menu latéral ;
- pointe vers la page existante `/rubrique` ;
- replace l’entrée après « Vallée de Sye et Gervanne », comme avant son retrait.

## Pourquoi

La page `/rubrique` existe toujours, mais son lien de navigation avait été remplacé par « Adhésion ». Elle était donc devenue inaccessible depuis l’interface du site.

## Impact

Les visiteurs peuvent à nouveau atteindre la rubrique saisonnière depuis le menu principal, sur ordinateur comme sur mobile.

## Validation

- `git diff --check` : OK
- analyse syntaxique Babel de `src/components/layout.js` : OK
- `npm run build` : le build démarre, puis s’arrête sur la configuration existante car le token API DatoCMS n’est pas présent dans l’environnement (`API token must be provided!`).
